### PR TITLE
Initial version

### DIFF
--- a/java/robox-slicer-extension/.gitignore
+++ b/java/robox-slicer-extension/.gitignore
@@ -1,0 +1,4 @@
+**/.project
+**/.classpath
+**/.settings
+**/target/

--- a/java/robox-slicer-extension/pom.xml
+++ b/java/robox-slicer-extension/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.roboxing</groupId>
+  <artifactId>robox-slicer-extension</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Robox Slicer Extension</name>
+  <url>http://www.roboxing.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>robox-slicer-flow</module>
+    <module>robox-slicer-control</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.2</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java/robox-slicer-extension/robox-slicer-control/pom.xml
+++ b/java/robox-slicer-extension/robox-slicer-control/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.roboxing</groupId>
+    <artifactId>robox-slicer-extension</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>robox-slicer-control</artifactId>
+
+  <name>Robox Slicer Extension Control</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.roboxing.slicerextension.control.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java/robox-slicer-extension/robox-slicer-control/src/main/java/com/roboxing/slicerextension/control/Main.java
+++ b/java/robox-slicer-extension/robox-slicer-control/src/main/java/com/roboxing/slicerextension/control/Main.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Robox Slicer Extension.
+ *
+ * Robox Slicer Extension is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Robox Slicer Extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Robox Slicer Extension.  If not, see <http://www.gnu.org/licenses/>.
+ *
+*/
+package com.roboxing.slicerextension.control;
+
+/**
+ * Hello world!
+ *
+ */
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}

--- a/java/robox-slicer-extension/robox-slicer-flow/pom.xml
+++ b/java/robox-slicer-extension/robox-slicer-flow/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.roboxing</groupId>
+    <artifactId>robox-slicer-extension</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>robox-slicer-flow</artifactId>
+
+  <name>Robox Slicer Extension Flow</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.roboxing.slicerextension.flow.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java/robox-slicer-extension/robox-slicer-flow/src/main/java/com/roboxing/slicerextension/flow/Main.java
+++ b/java/robox-slicer-extension/robox-slicer-flow/src/main/java/com/roboxing/slicerextension/flow/Main.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Robox Slicer Extension.
+ *
+ * Robox Slicer Extension is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Robox Slicer Extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Robox Slicer Extension.  If not, see <http://www.gnu.org/licenses/>.
+ *
+*/
+package com.roboxing.slicerextension.flow;
+
+/**
+ * Hello world!
+ *
+ */
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}


### PR DESCRIPTION
Here it is:

java/robox-slicer-extension
    robox-slicer-control - control jar - something to be invoked outside of the AM flow
    robox-slicer-flow - flow jar - something to be invoked by CuraEngine (or CuraEngine.exe)

Run mvn clean install from java/robox-slicer-extension to build all and find jar files in:

java/robox-slicer-extension/robox-slicer-control/target/robox-slicer-control-1.0-SNAPSHOT.jar
java/robox-slicer-extension/robox-slicer-flow/target/robox-slicer-flow-1.0-SNAPSHOT.jar

... ready to be run with java -jar option!